### PR TITLE
Adds additional fields to the indexer, Es mapping, and search.

### DIFF
--- a/oop-indexer/README.md
+++ b/oop-indexer/README.md
@@ -142,6 +142,9 @@ PUT documents
                 "identifier_doi": {
                     "type": "keyword"
                 },
+                "identifier_orcid": {
+                    "type": "keyword"
+                },
                 "resource_uri": {
                     "type": "keyword"
                 },
@@ -152,6 +155,36 @@ PUT documents
                     "type": "text"
                 },
                 "sourceKey": {
+                    "type": "keyword"
+                },
+                "publication_status": {
+                    "type": "keyword"
+                },
+                "current_status": {
+                    "type": "keyword"
+                },
+                "relation_uri": {
+                    "type": "keyword"
+                },
+                "bptype": {
+                    "type": "keyword"
+                },
+                "relation_is_part_of_series": {
+                    "type": "keyword"
+                },
+                "type": {
+                    "type": "keyword"
+                },
+                "subjects_other": {
+                    "type": "keyword"
+                },
+                "maturity_level": {
+                    "type": "keyword"
+                },
+                "notes": {
+                    "type": "text"
+                },
+                "coverage_spatial": {
                     "type": "keyword"
                 }
             }

--- a/oop-indexer/api/search.js
+++ b/oop-indexer/api/search.js
@@ -187,6 +187,12 @@ function buildElasticsearchQuery(keywords, terms, termURIs, fields, refereed) {
   return query;
 }
 
+/**
+ * Returns the list of fields that should be targeted in an Elasticsearch query. All fields
+ * are set to the default Elasticsearch boost value unless otherwise denoted by ^n.
+ * 
+ * @returns {array} Array of field names to target in a query
+ */
 function queryFields() {
   return [
           "contents", 
@@ -200,7 +206,20 @@ function queryFields() {
           "essential_ocean_variables", 
           "sustainable_development_goals", 
           "refereed",
-          "abstract^2"
+          "abstract^2",
+          "publication_status",
+          "current_status",
+          "relation_uri",
+          "language",
+          "bptype",
+          "relation_is_part_of_series",
+          "type",
+          "subjects_other",
+          "identifier_orcid",
+          "identifier_doi",
+          "maturity_level",
+          "notes",
+          "coverage_spatial"
          ];
 }
 


### PR DESCRIPTION
This PR updates the indexer mapping to include additional metadata fields which have been requested by the IODE team. It also updates the Es mapping to define these new fields and adds them to the searchable fields list for the search API.

I've also added a few comments and am attempting to improve the documentation for important functions but do not currently have any documentation.