### PR TITLE
Fix/36/fix missing dependencies

### DIFF
--- a/oop-indexer/.gitignore
+++ b/oop-indexer/.gitignore
@@ -9,3 +9,6 @@ ingest/scheduler/*.zip
 
 # Ignore private keys.
 keys/
+
+# Ignore node_modules
+node_modules

--- a/oop-indexer/Deployments.md
+++ b/oop-indexer/Deployments.md
@@ -53,6 +53,14 @@ The ingest and indexer pipeline is made up of a few different stacks, each with 
 
 The scheduler is responsible for polling the DSpace RSS feed to discover new documents that need ingesting. It creates a Lambda function and SNS Topic where new document handles are published.
 
+Since updating to Node.js 12.x dependencies must be included with the Lambda package. This function requires the `xml2js` library and must be installed prior to deploying. We use npm to manage dependencies. In order to install dependencies make sure you first have Node and npm installed. Most likely you'll need multiple versions of node on your machine so we recommend installing [nvm](https://github.com/nvm-sh/nvm). Once you have Node and npm installed navigate to the /secheduler directory and run:
+
+`npm install`
+
+This command will use the `package.json` file to install necessary dependencies into a `node_modules` directory. 
+
+Then use the `aws cloudformation` CLI to package and deploy the stack:
+
 `aws cloudformation package --template-file scheduler.yml --output-template-file scheduler-out.yml --s3-bucket obp-indexer-functions-{ENVIORNMENT} --profile {AWS_PROFILE}`
 
 `aws cloudformation deploy --template-file scheduler-out.yml --stack-name obp-scheduler-{ENVIRONMENT} --parameter-overrides Environment={ENVIORNMENT} --capabilities CAPABILITY_NAMED_IAM --profile {AWS_PROFILE}`

--- a/oop-indexer/ingest/scheduler/package-lock.json
+++ b/oop-indexer/ingest/scheduler/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "scheduler",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+    }
+  }
+}

--- a/oop-indexer/ingest/scheduler/package.json
+++ b/oop-indexer/ingest/scheduler/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "scheduler",
+  "version": "1.0.0",
+  "description": "",
+  "main": "scheduler.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "xml2js": "^0.4.23"
+  }
+}

--- a/oop-indexer/ingest/scheduler/scheduler-out.yml
+++ b/oop-indexer/ingest/scheduler/scheduler-out.yml
@@ -1,87 +1,64 @@
 AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
 Description: Leverages the Ocean Best Practices RSS feed to discover documents needing
   ingest.
-Outputs:
-  AvailableDocumentTopicArn:
-    Description: The topic ARN for available document subscribers.
-    Value:
-      Ref: AvailableDocumentTopic
 Parameters:
   Environment:
-    Default: staging
+    Type: String
     Description: staging, prod, or a development environment uniquely named across
       CF templates like stark
-    Type: String
+    Default: staging
   ScheduleInterval:
-    Default: 300
+    Type: Number
     Description: The amount of time in seconds to consider published documents valid
       to index. Also may just be how often this function is scheduled to run by e.g.
       CloudWatch events.
-    Type: Number
+    Default: 300
 Resources:
   AvailableDocumentTopic:
+    Type: AWS::SNS::Topic
     Properties:
       DisplayName:
         Fn::Sub: Available Documents Topic-#{Environment}
-    Type: AWS::SNS::Topic
-  InvokeSchedulerFromEventPermission:
-    Properties:
-      Action: lambda:InvokeFunction
-      FunctionName:
-        Fn::GetAtt:
-        - SchedulerFunction
-        - Arn
-      Principal: events.amazonaws.com
-      SourceArn:
-        Fn::GetAtt:
-        - SchedulerEventRule
-        - Arn
-    Type: AWS::Lambda::Permission
-  SchedulerEventRule:
-    Properties:
-      Description: Schedules the RSS checker (scheduler) to execute at a specific
-        interval
-      Name:
-        Fn::Sub: obp-scheduler-interval-rule-${Environment}
-      ScheduleExpression: rate(5 minutes)
-      State: ENABLED
-      Targets:
-      - Arn:
-          Fn::GetAtt:
-          - SchedulerFunction
-          - Arn
-        Id:
-          Fn::Sub: scheduler-event-id-${Environment}
-    Type: AWS::Events::Rule
   SchedulerExecutionRole:
+    Type: AWS::IAM::Role
     Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-        - Action:
-          - sts:AssumeRole
-          Effect: Allow
-          Principal:
-            Service:
-            - lambda.amazonaws.com
-        Version: '2012-10-17'
+      RoleName:
+        Fn::Sub: obp-scheduler-execution-role-${Environment}
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
-      - PolicyDocument:
+      - PolicyName: AllowPublishToDocumentTopic
+        PolicyDocument:
+          Version: '2012-10-17'
           Statement:
-          - Action:
-            - SNS:Publish
-            Effect: Allow
+          - Effect: Allow
             Resource:
               Ref: AvailableDocumentTopic
-          Version: '2012-10-17'
-        PolicyName: AllowPublishToDocumentTopic
-      RoleName:
-        Fn::Sub: obp-scheduler-execution-role-${Environment}
-    Type: AWS::IAM::Role
+            Action:
+            - SNS:Publish
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
   SchedulerFunction:
+    Type: AWS::Serverless::Function
     Properties:
-      CodeUri: s3://obp-scheduler-functions-prod/025eb56c1c738d045ba7137c81bb2da5
+      Handler: scheduler.handler
+      Runtime: nodejs12.x
+      Timeout: 60
+      CodeUri: s3://obp-indexer-functions-staging/39e905e08cfe4e1a08c6966109f6c57b
+      Role:
+        Fn::GetAtt:
+        - SchedulerExecutionRole
+        - Arn
+      FunctionName:
+        Fn::Sub: obp-scheduler-function-${Environment}
       Description: Periodically checks the OBP RSS feed for documents that need indexing.
       Environment:
         Variables:
@@ -89,14 +66,37 @@ Resources:
             Ref: AvailableDocumentTopic
           SCHEDULE_INTERVAL:
             Ref: ScheduleInterval
+  SchedulerEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Schedules the RSS checker (scheduler) to execute at a specific
+        interval
+      Name:
+        Fn::Sub: obp-scheduler-interval-rule-${Environment}
+      ScheduleExpression: rate(5 minutes)
+      Targets:
+      - Arn:
+          Fn::GetAtt:
+          - SchedulerFunction
+          - Arn
+        Id:
+          Fn::Sub: scheduler-event-id-${Environment}
+      State: ENABLED
+  InvokeSchedulerFromEventPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
       FunctionName:
-        Fn::Sub: obp-scheduler-function-${Environment}
-      Handler: scheduler.handler
-      Role:
         Fn::GetAtt:
-        - SchedulerExecutionRole
+        - SchedulerFunction
         - Arn
-      Runtime: nodejs12.x
-      Timeout: 60
-    Type: AWS::Serverless::Function
-Transform: AWS::Serverless-2016-10-31
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn:
+        Fn::GetAtt:
+        - SchedulerEventRule
+        - Arn
+Outputs:
+  AvailableDocumentTopicArn:
+    Description: The topic ARN for available document subscribers.
+    Value:
+      Ref: AvailableDocumentTopic

--- a/oop-indexer/ingest/scheduler/scheduler-out.yml
+++ b/oop-indexer/ingest/scheduler/scheduler-out.yml
@@ -52,7 +52,7 @@ Resources:
       Handler: scheduler.handler
       Runtime: nodejs12.x
       Timeout: 60
-      CodeUri: s3://obp-indexer-functions-staging/39e905e08cfe4e1a08c6966109f6c57b
+      CodeUri: s3://obp-indexer-functions-staging/e7c9ca81506cf98f7d7ae2b57d31fd88
       Role:
         Fn::GetAtt:
         - SchedulerExecutionRole

--- a/oop-indexer/ingest/scheduler/scheduler.js
+++ b/oop-indexer/ingest/scheduler/scheduler.js
@@ -9,112 +9,159 @@ const https = require('https');
 const xml2js = require('xml2js');
 
 const topicArn = process.env.DOCUMENT_TOPIC_ARN;
+
 const scheduleInterval = process.env.SCHEDULE_INTERVAL ? parseInt(process.env.SCHEDULE_INTERVAL) : 300;
 
-const obp = {
+const dspace = {
   host: 'www.oceanbestpractices.net',
   path: '/feed/rss_2.0/site',
   accept: 'application/json',
-  userAgent: "Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5"
-}
-
-const xmlOpts = {
-  explicitCharkey: false,
-  trim: false,
-  normalize: false,
-  explicitRoot: false,
-  emptyTag: null,
-  explicitArray: true,
-  ignoreAttrs: false,
-  mergeAttrs: false,
-  validator: null
+  userAgent: "Mozill;a/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5"
 };
 
-exports.handler = (event, context, callback) => {
+exports.handler = async (event) => {
+  
+  try {
+    // Fetch the raw RSS feed.
+    const rawFeed = await getFeedContent();
+    
+    // Parse the RSS feed since we received XML.
+    const parsedFeed = await parseXMLString(rawFeed);
+      
+    // Parse out the last published date and use it to determine whether or
+    // not we should index new documents.
+    const pubDate = parsedFeed['channel'][0]['pubDate'][0]["_"];
+    const lastPublishedDate = Date.parse(pubDate);
+    
+    let numDocumentsPublished = 0;
+    if (shouldPublishDocuments(lastPublishedDate)) {
+      // If we have new or updated documents we should publish them to our SNS topic.
+      numDocumentsPublished = await publishDocuments(parsedFeed['channel'][0]['item']); 
+    } 
+
+    // Return num documents published response.
+    return { statusCode: 200, body: JSON.stringify({ documents: numDocumentsPublished }) };
+  } catch (err) {
+    console.log('Error:\n' + JSON.stringify(err));
+    return { statusCode: 500, body: JSON.stringify({ err: err }) };
+  }
+
+};
+
+/**
+ * Fetches the RSS feed from the configured DSpace host.
+ * 
+ * @returns The raw (XML) RSS feed from DSpace.
+ */
+async function getFeedContent() {
   const opts = {
-    hostname: obp.host,
-    path: obp.path,
+    hostname: dspace.host,
+    path: dspace.path,
     headers: {
-      'Accept': obp.accept,
-      'User-Agent': obp.userAgent
+      'Accept': dspace.accept,
+      'User-Agent': dspace.userAgent
     }
   };
 
-  https.get(opts, function(res) {
-    var data = '';
-
-    res.on('data', function(chunk) {
-      data += chunk;
-    });
-
-    res.on('error', function(err) {
-      respondWithError(err, callback);
-    });
-
-    res.on('end', function() {
-      var feed = parseXMLString(data, function(err, result) {
-        if (err) {
-          respondWithError(err, callback);
-        } else {
-          const pubDate = result['channel'][0]['pubDate'][0]["_"];
-          const lastPublishedDate = Date.parse(pubDate);
-          
-          if (shouldPublishDocuments(lastPublishedDate)) {
-            publishDocuments(result['channel'][0]['item'], callback);    
-          } else {
-            callback(null, {statusCode: 200, body: JSON.stringify({ documents: 0 })});
-          }
-        }
+  return new Promise((resolve, reject) => {
+    https.get(opts, function(res) {
+      var data = '';
+  
+      res.on('data', function(chunk) {
+        data += chunk;
+      });
+  
+      res.on('error', function(err) {
+        reject(err);
+      });
+  
+      res.on('end', function() {
+        resolve(data);
       });
     });
   });
 }
 
+/**
+ * Returns a boolean indiciting whether or not we shoudl publish documents from the RSS feed based
+ * on when the RSS feed was published and the last time we checked it. Set the `scheduleInterval` to
+ * -1 to always pass this test.
+ * 
+ * @param {Date} publishedDate The published date of the RSS feed.
+ * 
+ * @returns Whether or not we should publish new documents based 
+ *          on the last time we checked the RSS feed
+ */
 function shouldPublishDocuments(publishedDate) {
   if (scheduleInterval === -1) {
     return true;
   }
 
   var scheduleIntervalDate = new Date();
-  scheduleIntervalDate.setSeconds(scheduleInterval * -1)
+  scheduleIntervalDate.setSeconds(scheduleInterval * -1);
 
   return publishedDate >= scheduleIntervalDate;
 }
 
-function publishDocuments(docs, callback) {
+/**
+ * Publishes a list of documents to the configured SNS topic. This function parses out the 'link' value
+ * of a document and uses that as the message content for the SNS message.
+ * 
+ * @param {*} docs List of documents that should be published to the configured SNS topic.
+ * 
+ * @returns The number of documents successfully published.
+ */
+async function publishDocuments(docs) {
   var numPublished = 0;
-  docs.forEach((doc) => {
-    var params = {
-      Message: doc['link'][0],
-      TopicArn: topicArn,
+  
+  for (const doc of docs) {
+    try {
+      const params = {
+        Message: doc['link'][0],
+        TopicArn: topicArn,
+      };
+      
+      await sns.publish(params).promise();
+      
+      numPublished += 1;
+    } catch (err) {
+      console.log('Error publishing document:\n', JSON.stringify(err));
     }
-
-    sns.publish(params, function(err, data) {
-      if (err) {
-        console.log('Error publishing document:\n', JSON.stringify(err));
-      } else {
-        numPublished += 1;
-      }
-    });
-  });
-
-  callback(null, {statusCode: 200, body: JSON.stringify({ documents: numPublished })});
+  }
+  
+  return numPublished;
 }
 
-function respondWithError(err, callback) {
-  console.log('Error:\n' + JSON.stringify(err));
-  callback(err, {statusCode: 500, body: JSON.stringify({'err': err})});
-} 
+/**
+ * Parses a given raw XML RSS feed and returns it as an object.
+ * 
+ * @param {String} xmlString The raw XML to parse.
+ * 
+ * @returns The given XML as an object.
+ */
+async function parseXMLString(xmlString) {
+  return new Promise((resolve, reject) => {
+    const xmlOpts = {
+      explicitCharkey: false,
+      trim: false,
+      normalize: false,
+      explicitRoot: false,
+      emptyTag: null,
+      explicitArray: true,
+      ignoreAttrs: false,
+      mergeAttrs: false,
+      validator: null
+    };
 
-function parseXMLString(xmlString, callback) {
-  const parser = new xml2js.Parser(xmlOpts);
+    const parser = new xml2js.Parser(xmlOpts);
 
-  parser.parseString(xmlString, function(err, result) {
-    if (err) {
-      callback(err, null);
-    } else {
-      //console.log('Result\n', JSON.stringify(result['channel'][0]['item']));
-      callback(err, result);
-    }
+    parser.parseString(xmlString, function(err, result) {
+      if (err) {
+        reject(err);
+      } else {
+        //console.log('Result\n', JSON.stringify(result['channel'][0]['item']));
+        resolve(result);
+      }
+    });
   });
 }


### PR DESCRIPTION
This PR addresses an issue where the scheduler function (RSS reader) could not find the xml library dependency after updating to Node.js 12.x. 

I've updated the README to include a few more instructions required prior to deploying the scheduler function.

I've also refactored the code to use `async/await` syntax which made things easier to read. I've also added documentation for each function within this Lambda function. 

I've also fixed the response for this function to correctly return the number of documents successfully published to the SNS topic as a result of this function running.

I've already deployed this change to `staging` and verified it works.