### PR TITLE
OBP-262: Adds Privacy Policy link to the footer

### DIFF
--- a/oop-web/src/js/components/FooterLinks.js
+++ b/oop-web/src/js/components/FooterLinks.js
@@ -22,6 +22,11 @@ const footer_links = [
     class: '',
   },
   {
+    to: 'https://repository.oceanbestpractices.org/page/policy',
+    title: 'Privacy Policy',
+    class: '',
+  },
+  {
     to: '/tagger',
     title: 'OceanKnowledge Tagger',
     class: 'tagger__footer-link',


### PR DESCRIPTION
https://element84.atlassian.net/browse/OBP-262

This adds the Privacy Policy link to the link list in the footer.

NOTE: It should be verified that the responsive behavior (wrapping) of these links is acceptable.