### PR TITLE
OBP-261: Changes author list delimiter to semi-colon

### DIFF
--- a/oop-web/src/js/components/Result.js
+++ b/oop-web/src/js/components/Result.js
@@ -76,7 +76,7 @@ class Result extends Component {
 
     var authorList = null;
     if (this.props.author) {
-      authorList = Array.isArray(this.props.author) ? this.props.author.join(", ") : [this.props.author].join(", ")
+      authorList = Array.isArray(this.props.author) ? this.props.author.join("; ") : [this.props.author].join(", ")
     }
 
     let result_title;


### PR DESCRIPTION
https://element84.atlassian.net/browse/OBP-261

This changes the delimiter between author names in search results to a semi-colon.