### PR TITLE
OBP-272: Removes mentions of (Beta) and renders of HeaderBanner

### DIFF
--- a/oop-web/src/js/components/FooterLinks.js
+++ b/oop-web/src/js/components/FooterLinks.js
@@ -59,7 +59,7 @@ class FooterLinks extends Component {
               Go to Submission Site
             </Superlink>
             <Superlink class_name="link-list__link" to="/tagger" event_category="footer" event_action="link" event_label="Ocean Knowledge Tagger">
-              OceanKnowledge Tagger (Beta)
+              OceanKnowledge Tagger
             </Superlink>
           </LinkListItemToggle>
         </ul>

--- a/oop-web/src/js/components/Header.js
+++ b/oop-web/src/js/components/Header.js
@@ -1,14 +1,12 @@
 import React, { Component } from "react";
 
 import SearchBar from './SearchBar';
-import HeaderBanner from './HeaderBanner';
 import Superlink from './Superlink';
 
 class Header extends Component {
   render() {
     return (
       <header className="header">
-        <HeaderBanner />
         <section className="header__main-container">
           <Superlink to="/" class_name="header__logo-link" event_category="header" event_action="link" event_label="logo | Ocean Best Practices">
             <h1 className="header__logo ir">Ocean Best Practices</h1>

--- a/oop-web/src/js/layouts/Main.js
+++ b/oop-web/src/js/layouts/Main.js
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import { connect } from 'react-redux';
 
 import Wrapper from './Wrapper';
-import HeaderBanner from '../components/HeaderBanner';
 import SearchBar from '../components/SearchBar';
 import SearchTipsModal from '../components/SearchTipsModal';
 import FullScreenModal from '../components/FullScreenModal';
@@ -60,8 +59,6 @@ class Main extends Component {
         <Wrapper header={false} page="landing" childrenContainerClass="landing">
           <section className='landing__header'>
 
-            <HeaderBanner />
-
             <div className='link-list--landing'>
 
               <ul className="link-list link-list--horizontal">
@@ -90,7 +87,7 @@ class Main extends Component {
                     Go to Submission Site
                   </Superlink>
                   <Superlink class_name="link-list__link" to="/tagger" event_category="header" event_action="link" event_label="Ocean Knowledge Tagger">
-                    OceanKnowledge Tagger (Beta)
+                    OceanKnowledge Tagger
                   </Superlink>
                 </LinkListItemToggle>
               </span>

--- a/oop-web/src/js/layouts/Tagger.js
+++ b/oop-web/src/js/layouts/Tagger.js
@@ -104,7 +104,7 @@ class Tagger extends Component {
     // input view of the tagger
     const taggerInput = (
       <div>
-        <span className="tagger__header">OceanKnowledge Tagger (Beta)</span>
+        <span className="tagger__header">OceanKnowledge Tagger</span>
         <span className="tagger__info">Welcome to the OceanKnowledge Tagger! This tool will "tag" or annotate your text with matching terms from quality-controlled, FAIR vocabularies and ontologies. You can download a ranked list of tags in CSV or JSON format</span>
         <div className="tagger__form-wrapper">
           <form onSubmit={this.handleSubmit}>


### PR DESCRIPTION
https://element84.atlassian.net/browse/OBP-272

Removes user-facing mentions of (Beta), removes renders of HeaderBanner in Main.js and Header.js, but leaves the HeaderBanner component (and its styling) intact for possible use later.