### PR TITLE
OBP-238 Removes optional chaining

### DIFF
--- a/oop-web/src/js/components/SearchSidebar.js
+++ b/oop-web/src/js/components/SearchSidebar.js
@@ -16,7 +16,7 @@ class SearchSidebar extends Component {
   }
 
   static getDerivedStateFromProps(props, prevState) {
-    if (props.termsReducer.activeTerms.title !== prevState.termsReducer?.activeTerms.title) {
+    if (prevState.termsReducer && props.termsReducer.activeTerms.title !== prevState.termsReducer.activeTerms.title) {
       return ({ activeTags: props.termsReducer.activeTerms.title })
     }
     return null


### PR DESCRIPTION
Create-react-app's config doesn't support optional chaining, so rather than try to add config, I just replaced it with old-school js.