### PR TITLE
OBP-277 Moves journal title placement in results

### DIFF
--- a/oop-web/src/js/components/Result.js
+++ b/oop-web/src/js/components/Result.js
@@ -130,15 +130,17 @@ class Result extends Component {
               }
             </div>
             { result_title }
-            <div className="result__journal_author">
-              {
-                this.props.journal_title
-                ? <span className="result__journal-title">{this.props.journal_title}</span>
-                : null
-              }
+            <div className="result__author">
               {
                 authorList
-                ? <span className="result__author">{ this.props.journal_title ? ", " + authorList : authorList }</span>
+                ? <span className="result__author">{authorList}</span>
+                : null
+              }
+            </div>
+            <div className="result__journal-title">
+              {
+                this.props.journal_title
+                ? <span>{this.props.journal_title}</span>
                 : null
               }
             </div>

--- a/oop-web/src/js/components/Result.js
+++ b/oop-web/src/js/components/Result.js
@@ -132,16 +132,12 @@ class Result extends Component {
             { result_title }
             <div className="result__author">
               {
-                authorList
-                ? <span className="result__author">{authorList}</span>
-                : null
+                authorList || null
               }
             </div>
             <div className="result__journal-title">
               {
-                this.props.journal_title
-                ? <span>{this.props.journal_title}</span>
-                : null
+                this.props.journal_title || null
               }
             </div>
             <div className="result__highlight"> { this.componentListFromStrings(this.props.highlight) } </div>

--- a/oop-web/src/scss/components/_result.scss
+++ b/oop-web/src/scss/components/_result.scss
@@ -36,6 +36,7 @@
   font-weight: normal;
   font-style: italic;
   font-size: 18px;
+  margin-top: 10px;
 }
 
 .result__author {


### PR DESCRIPTION
https://element84.atlassian.net/browse/OBP-277

This moves the placement of the journal title in results _from_ prepending the author list _to_ below that list.