### PR TITLE
OBP-282: Changes 'Publisher' to 'Issuing Agency' in dropdown and tips

### DIFF
--- a/oop-web/src/js/components/SearchTipsModal.js
+++ b/oop-web/src/js/components/SearchTipsModal.js
@@ -79,7 +79,7 @@ bar to refine your search. You can change how new terms or phrases relate to you
               <SearchTipsModalItem
                 number='2'
                 header='Searching by metadata field'
-                content='You can restrict your search to a single metadata field – such as the Title, Author, or Publisher of a document - by using the dropdown
+                content='You can restrict your search to a single metadata field – such as the Title, Author, or Issuing Agency of a document - by using the dropdown
                 menu to the left of the search bar.'
               />
                 <p>You can also restrict your search to the body of documents in the archive, ignoring the content

--- a/oop-web/src/js/reducers/fields.js
+++ b/oop-web/src/js/reducers/fields.js
@@ -64,7 +64,7 @@ const initialState = [
     active_search: false,
   },
   {
-    title: 'Publisher',
+    title: 'Issuing Agency',
     id: 'publisher',
     value: [
       'publisher',


### PR DESCRIPTION
https://element84.atlassian.net/browse/OBP-282

The word "Publisher" appeared in the search fields dropdown and in the search tips modal. This replaces both instances with "Issuing Agency".