### PR TITLE
Adds primary author to indexer to support sort.

### DIFF
--- a/ingest/lambdas/indexer.test.ts
+++ b/ingest/lambdas/indexer.test.ts
@@ -200,6 +200,74 @@ describe('indexer', () => {
     });
   });
 
+  describe('getPrimaryAuthor', () => {
+    test('should return the first author listed in the DSpace item metadata', () => {
+      const metadata = [
+        {
+          key: 'dc.date.accessioned',
+          value: '2021-07-05T19:56:13Z',
+          language: '',
+          element: 'date',
+          qualifier: 'accessioned',
+          schema: 'dc',
+        },
+        {
+          key: 'dc.date.available',
+          value: '2019-03-08T14:46:45Z',
+          language: '',
+          element: 'date',
+          qualifier: 'available',
+          schema: 'dc',
+        },
+        {
+          key: 'dc.contributor.author',
+          value: 'Paul Pilone',
+          language: '',
+          element: 'text',
+          qualifier: 'available',
+          schema: 'dc',
+        },
+        {
+          key: 'dc.contributor.author',
+          value: 'Marc Huffnagle',
+          language: '',
+          element: 'text',
+          qualifier: 'available',
+          schema: 'dc',
+        },
+      ];
+
+      const result = indexer.getPrimaryAuthor(metadata);
+      expect(result).toEqual({
+        _primaryAuthor: 'Paul Pilone',
+      });
+    });
+
+    test('should return undefined if no author is found in the DSpace item metadata', () => {
+      const metadata = [
+        {
+          key: 'dc.date.accessioned',
+          value: '2021-07-05T19:56:13Z',
+          language: '',
+          element: 'date',
+          qualifier: 'accessioned',
+          schema: 'dc',
+        },
+        {
+          key: 'dc.date.available',
+          value: '2019-03-08T14:46:45Z',
+          language: '',
+          element: 'date',
+          qualifier: 'available',
+          schema: 'dc',
+        },
+      ];
+
+      const result = indexer.getPrimaryAuthor(metadata);
+      expect(result).toBeUndefined();
+    });
+  });
+
   describe('getThumbnailRetrieveLink', () => {
     test('should return the thumbnail retrieve link', () => {
       const bitstreams = [
@@ -342,6 +410,14 @@ describe('indexer', () => {
               {
                 key: 'dc.title',
                 value: 'Hello document with a PDF!',
+              },
+              {
+                key: 'dc.contributor.author',
+                value: 'Paul Pilone',
+              },
+              {
+                key: 'dc.contributor.author',
+                value: 'Marc Huffnagle',
               },
             ],
           }
@@ -563,11 +639,21 @@ describe('indexer', () => {
                 key: 'dc.title',
                 value: 'Hello document with a PDF!',
               },
+              {
+                key: 'dc.contributor.author',
+                value: 'Paul Pilone',
+              },
+              {
+                key: 'dc.contributor.author',
+                value: 'Marc Huffnagle',
+              },
             ],
             dc_title: 'Hello document with a PDF!',
             dc_date_accessioned: '2021-07-05T19:56:13Z',
+            dc_contributor_author: ['Paul Pilone', 'Marc Huffnagle'],
             _bitstreamText: 'Bitstream text for 01ebed91-218a-4465-8a67-f6712ff3cfb7.',
             _bitstreamTextKey: '01ebed91-218a-4465-8a67-f6712ff3cfb7.txt',
+            _primaryAuthor: 'Paul Pilone',
             _terms: [
               {
                 label: 'Hello',

--- a/lib/open-search-schemas.ts
+++ b/lib/open-search-schemas.ts
@@ -24,6 +24,7 @@ export type DocumentItemTerm = z.infer<typeof documentItemTermSchema>;
 
 export const documentItemSchema = dspaceItemSchema.extend({
   _bitstreamText: z.string().optional(),
+  _primaryAuthor: z.string().optional(),
   _terms: z.array(documentItemTermSchema).optional(),
   dc_title: z.string(),
 });

--- a/website/src/js/data/sort-items.json
+++ b/website/src/js/data/sort-items.json
@@ -7,12 +7,12 @@
   {
     "label": "AUTHOR",
     "direction": "asc",
-    "filter": "dc_contributor_author.keyword:asc"
+    "filter": "_primaryAuthor.keyword:asc"
   },
   {
     "label": "AUTHOR",
     "direction": "desc",
-    "filter": "dc_contributor_author.keyword:desc"
+    "filter": "_primaryAuthor.keyword:desc"
   },
   {
     "label": "PUBLISHER",


### PR DESCRIPTION
Fixes OBP-260 where the author sort wasn't working correctly. This was because the "author" metadata field is actually an array so sorting doesn't work. I've added a "primary author" index field and it's populated by the first author in the metadata list (confirmed with Pauline this represents the author we should sort by). Updated the website sort-items to use the new field.