### PR TITLE
Fix DSpace client missing expand parameter.

### DIFF
--- a/ingest/lambdas/metadata-downloader.test.ts
+++ b/ingest/lambdas/metadata-downloader.test.ts
@@ -36,6 +36,9 @@ describe('metadata-downloader.handler()', () => {
 
     nock('https://dspace.test.com')
       .get('/rest/items/38c7d808-aa26-4ed4-a3e4-3458b989d2d4')
+      .query({
+        expand: 'bitstreams,metadata',
+      })
       .reply(200, mockItem);
 
     const mockEvent = {
@@ -61,6 +64,9 @@ describe('metadata-downloader.handler()', () => {
   test('should throw an error when the a DSpace item with UUID from SNS is not found', async () => {
     nock('https://dspace.test.com')
       .get('/rest/items/38c7d808-aa26-4ed4-a3e4-3458b989d2d4')
+      .query({
+        expand: 'bitstreams,metadata',
+      })
       .reply(404);
 
     const mockEvent = {
@@ -85,6 +91,9 @@ describe('metadata-downloader.handler()', () => {
 
     nock('https://dspace.test.com')
       .get('/rest/items/38c7d808-aa26-4ed4-a3e4-3458b989d2d4')
+      .query({
+        expand: 'bitstreams,metadata',
+      })
       .reply(200, {
         uuid: '38c7d808-aa26-4ed4-a3e4-3458b989d2d4',
         handle: 'abc/123',

--- a/ingest/lambdas/metadata-downloader.ts
+++ b/ingest/lambdas/metadata-downloader.ts
@@ -21,6 +21,8 @@ export const handler = async (event: unknown) => {
   const dspaceEndpoint = getStringFromEnv('DSPACE_ENDPOINT');
   const dspaceItemBucket = getStringFromEnv('DOCUMENT_METADATA_BUCKET');
 
+  console.log(`INFO: Getting DSpace item with UUID: ${uuid}`);
+
   try {
     const dspaceItem = await dspaceClient.getItem(
       dspaceEndpoint,
@@ -36,9 +38,9 @@ export const handler = async (event: unknown) => {
       dspaceItem
     );
 
-    console.log(`INFO: Successfully uploaded metadata for item: ${dspaceItem.uuid}`);
+    console.log(`INFO: Successfully uploaded DSpace item: ${dspaceItem.uuid}`);
   } catch (error) {
-    console.log(`ERROR: Failed to upload metadata with error: ${error}`);
+    console.log(`ERROR: Failed to upload DSpace item with error: ${error}`);
     throw error;
   }
 };

--- a/lib/dspace-client.test.ts
+++ b/lib/dspace-client.test.ts
@@ -96,6 +96,9 @@ This is a new line!
 
       nock('https://repository.oceanbestpractices.org')
         .get('/rest/items/abc123')
+        .query({
+          expand: 'bitstreams,metadata',
+        })
         .reply(200, mockItem);
 
       const item = await dspaceClient.getItem('https://repository.oceanbestpractices.org', 'abc123');
@@ -105,6 +108,9 @@ This is a new line!
     test('should return undefined if the item is not found', async () => {
       nock('https://repository.oceanbestpractices.org')
         .get('/rest/items/b5789ae4-611a-4c6e-8b23-67e29cf01e31')
+        .query({
+          expand: 'bitstreams,metadata',
+        })
         .reply(404);
 
       // This is a valid format for a UUID but the item doesn't exist.
@@ -139,7 +145,7 @@ This is a new line!
       nock('https://repository.oceanbestpractices.org')
         .get('/rest/items')
         .query({
-          expand: 'none',
+          expand: 'bitstreams,metadata',
           limit: 50,
           offset: 0,
         })

--- a/lib/dspace-client.ts
+++ b/lib/dspace-client.ts
@@ -91,7 +91,7 @@ export const getItems = async (
   searchParams: GetItemsSearchParams = {}
 ): Promise<DSpaceItem[]> => {
   const {
-    expand = 'none',
+    expand = 'bitstreams,metadata',
     limit = 50,
     offset = 0,
   } = searchParams;
@@ -128,6 +128,9 @@ export const getItem = async (
   try {
     const getItemResponseBody = await got.get(`${endpoint}/rest/items/${uuid}`, {
       ...headers,
+      searchParams: {
+        expand: 'bitstreams,metadata',
+      },
       responseType: 'json',
       resolveBodyOnly: true,
     });


### PR DESCRIPTION
The `getItem(s)` functions were missing the `expand` query parameter which meant our code failed zod validation because bitstreams and metadata are required.