### PR TITLE
fixes return value for totalResults from search api

### DIFF
--- a/website/src/js/reducers/search.js
+++ b/website/src/js/reducers/search.js
@@ -55,7 +55,7 @@ export default (state = initialState, action) => {
         ...state,
         items: action.response.hits.hits,
         activePage: action.response.activePage,
-        totalResults: action.response.hits.total
+        totalResults: action.response.hits.total.value
       };
     case SEARCH_HAS_ERRORED:
       return {


### PR DESCRIPTION
the api used to return a number for the `hits.total`, that number is now in `hits.total.value`