### PR TITLE
Feature 187 - moved clear all to the left of Search Tips

### DIFF
--- a/website/src/js/components/SearchBarAdvancedStatus.js
+++ b/website/src/js/components/SearchBarAdvancedStatus.js
@@ -34,13 +34,12 @@ class SearchBarAdvancedStatus extends Component {
       <div className="searchbar__advanced--status">
 
         <ul>
-          <li>
-            <SearchTipsModal call='Search Tips' location="searchbar" />
-          </li>
+       
           <li>
             <Superlink to="/" event_category="searchbar" event_action="clear search" event_label="Clear All" onClick={this.handleClearClick}>
               Clear All
             </Superlink>
+            <SearchTipsModal call='Search Tips' location="searchbar" />
           </li>
         </ul>
 
@@ -90,3 +89,4 @@ const SearchBarAdvancedStatusOptions = ({options}) => {
   );
 
 }
+

--- a/website/src/scss/components/_searchbar.scss
+++ b/website/src/scss/components/_searchbar.scss
@@ -329,7 +329,7 @@
     font-size: .9rem;
     text-decoration: underline;
     :first-child {
-      margin-right: .4rem;
+      margin-right: .6rem;
     }
     :last-child {
       display: inline-block;

--- a/website/src/scss/components/_searchbar.scss
+++ b/website/src/scss/components/_searchbar.scss
@@ -325,13 +325,17 @@
   }
 
   li {
-    display: inline-block;
-    margin: 0 .6rem 0 0;
-
-    &:last-child {
+    margin: 0 .6rem 0rem 0;
+    font-size: .9rem;
+    text-decoration: underline;
+    :first-child {
+      margin-right: .4rem;
+    }
+    :last-child {
+      display: inline-block;
       margin-right: 0;
-      font-size: 0.9rem;
-      text-decoration: underline;
+      font-size: .7rem;
+      text-decoration: none;
     }
   }
 

--- a/website/src/scss/layouts/_grid.scss
+++ b/website/src/scss/layouts/_grid.scss
@@ -18,7 +18,7 @@
         width:13.3333333333%;
     }
     .col-3{
-        width:24%;
+        width:25%;
     }
     .col-4{
         width:32%;

--- a/website/src/scss/layouts/_grid.scss
+++ b/website/src/scss/layouts/_grid.scss
@@ -18,7 +18,7 @@
         width:13.3333333333%;
     }
     .col-3{
-        width:22%;
+        width:24%;
     }
     .col-4{
         width:32%;

--- a/website/src/scss/main.css
+++ b/website/src/scss/main.css
@@ -839,7 +839,7 @@ html {
   .col-2 {
     width: 13.3333333333%; }
   .col-3 {
-    width: 22%; }
+    width: 24%; }
   .col-4 {
     width: 32%; }
   .col-6 {
@@ -1712,12 +1712,16 @@ html {
     padding: 0;
     margin: 0; }
   .searchbar__advanced--status li {
-    display: inline-block;
-    margin: 0 .6rem 0 0; }
-    .searchbar__advanced--status li:last-child {
+    margin: 0 .6rem 0rem 0;
+    font-size: .9rem;
+    text-decoration: underline; }
+    .searchbar__advanced--status li :first-child {
+      margin-right: .4rem; }
+    .searchbar__advanced--status li :last-child {
+      display: inline-block;
       margin-right: 0;
-      font-size: 0.9rem;
-      text-decoration: underline; }
+      font-size: .7rem;
+      text-decoration: none; }
   .searchbar__advanced--status div,
   .searchbar__advanced--status .tip__label {
     display: block;

--- a/website/src/scss/main.css
+++ b/website/src/scss/main.css
@@ -839,7 +839,7 @@ html {
   .col-2 {
     width: 13.3333333333%; }
   .col-3 {
-    width: 24%; }
+    width: 25%; }
   .col-4 {
     width: 32%; }
   .col-6 {
@@ -1716,7 +1716,7 @@ html {
     font-size: .9rem;
     text-decoration: underline; }
     .searchbar__advanced--status li :first-child {
-      margin-right: .4rem; }
+      margin-right: .6rem; }
     .searchbar__advanced--status li :last-child {
       display: inline-block;
       margin-right: 0;


### PR DESCRIPTION
-move clear all to left of search tips
-fixed bug in develop branch where at very specific screen size "clear all" and "search tips" would stack on top of each other (changed col-3 width to 25% instead of 22% in website/src/scss/layouts/_grid.scss)

Original:

<img width="1680" alt="Fullscreen_6_9_22__12_07_PM-2" src="https://user-images.githubusercontent.com/107065749/172894466-85779478-4ece-4ce2-b8e4-8ecf30682904.png">

Changes:

<img width="1680" alt="Fullscreen_6_9_22__12_07_PM" src="https://user-images.githubusercontent.com/107065749/172894555-e0fd3fec-9a44-4838-b63e-a20b49e36dc9.png">


 