### PR TITLE
bug/232 fixed landing page not applying the correct field

### DIFF
--- a/website/src/js/components/SearchBar.js
+++ b/website/src/js/components/SearchBar.js
@@ -106,7 +106,7 @@ class SearchBar extends Component {
    * @description Pushes the given active search string to the browser history
    */
 
-  navigateToSearch(activeSearch, fields ='all') {
+  navigateToSearch(activeSearch, fields = activeFieldsString(this.props.fields)) {
 
     const active_sort = activeSortOption(this.props.options);
     const route = formSearchRoute({


### PR DESCRIPTION
ended up being half a line of code - setting the 'fields' variable to the current active field instead of always 'all' when the fields variable is not defined. Weird case that only applies whenever going from landing page to search page. 