### PR TITLE
Feature 237 - Filter button now displays active filters

### DIFF
--- a/website/src/js/components/Dropdown.js
+++ b/website/src/js/components/Dropdown.js
@@ -122,6 +122,9 @@ class Dropdown extends Component {
 
   dropdownIconClassName() {
     let class_name = 'fa';
+    if (this.props.has_active_items) {
+      return 'fa fa-filter fa-lg';
+    }
     return `${class_name} ${this.state.is_open ? "fa-caret-up" : "fa-caret-down"}`;
   }
 

--- a/website/src/js/components/Dropdown.js
+++ b/website/src/js/components/Dropdown.js
@@ -113,6 +113,20 @@ class Dropdown extends Component {
       label: event_label || this.label(),
     });
 
+  }/**
+   * 
+   * dropdownClassName
+   * @description class of the dropdown button - changes based on page
+   */
+
+  dropdownClassName() {
+    let className = "button button__dropdown";
+    console.log(this.props.page)
+    if (this.props.page === "landing") {
+      
+      className += " landing-page"
+    }
+    return className;
   }
 
   /**
@@ -158,7 +172,7 @@ class Dropdown extends Component {
     return (
       <div ref={this.setRef} className="dropdown" data-has-active-items={this.props.has_active_items}>
 
-        <a className="button button__dropdown" onClick={this.handleDropdownLinkClick}>
+        <a className={this.dropdownClassName()} onClick={this.handleDropdownLinkClick}>
           { this.label() }
           <i className={this.dropdownIconClassName()}></i>
         </a>

--- a/website/src/js/components/SearchBar.js
+++ b/website/src/js/components/SearchBar.js
@@ -209,7 +209,7 @@ class SearchBar extends Component {
 
           <div className="searchbar__input--append">
 
-            <SearchOptionsDropdown />
+            <SearchOptionsDropdown page={this.props.page}/>
 
             <div className="searchbar__input--append--button">
 

--- a/website/src/js/components/SearchOptionsDropdown.js
+++ b/website/src/js/components/SearchOptionsDropdown.js
@@ -57,9 +57,19 @@ class SearchOptionsDropdown extends Component {
     return this.options().filter(option => !!(option.value)).length > 0;
   }
 
+  getLabel() {
+    let label = this.options().filter(options => !!(options.value))
+    label = label.map(options => options.title)
+    label = label.join(', ');
+    if (label.length === 0) {
+      return "Filter Options"
+    }
+    return label
+  }
+
   render() {
     return (
-      <Dropdown label="Filter Options" items={this.options()} item_component={DropdownToggle} has_active_items={this.hasActiveOptions()} item_onClick={this.handleItemClick} />
+      <Dropdown label={this.getLabel()} items={this.options()} item_component={DropdownToggle} has_active_items={this.hasActiveOptions()} item_onClick={this.handleItemClick} />
     );
   }
 

--- a/website/src/js/components/SearchOptionsDropdown.js
+++ b/website/src/js/components/SearchOptionsDropdown.js
@@ -69,7 +69,7 @@ class SearchOptionsDropdown extends Component {
 
   render() {
     return (
-      <Dropdown label={this.getLabel()} items={this.options()} item_component={DropdownToggle} has_active_items={this.hasActiveOptions()} item_onClick={this.handleItemClick} />
+      <Dropdown page={this.props.page} label={this.getLabel()} items={this.options()} item_component={DropdownToggle} has_active_items={this.hasActiveOptions()} item_onClick={this.handleItemClick} />
     );
   }
 

--- a/website/src/js/layouts/Main.js
+++ b/website/src/js/layouts/Main.js
@@ -117,7 +117,7 @@ class Main extends Component {
         <section className="landing__search-container">
           <img className="landing__obp-logo" src={unesco_ioc_obp_logo} alt="United Nations, Educational, Scientific and Cultural Organization Logo | Intergovernmental Oceanographic Commission Logo | Ocean Best Practices Logo" width="591" height="234"/>
           <div className="landing__search">
-            <SearchBar history={this.props.history}/>
+            <SearchBar page="landing" history={this.props.history}/>
           </div>
           <button className="button landing__search-button"
             onClick={this.handleSearchButtonClick.bind(this)}

--- a/website/src/scss/components/_dropdown.scss
+++ b/website/src/scss/components/_dropdown.scss
@@ -7,8 +7,52 @@
 
   &[data-has-active-items="true"] {
     .button__dropdown {
+      font-weight: bold;
       color: white;
+      width: 100%;
       background-color: $secondary-blue;
+      white-space: initial;
+      display: flex;
+      justify-content: center;
+      flex-direction: column;
+      vertical-align: middle;
+      padding: 0, 1.5em, 0, 1.5em;
+      
+      @media (max-width: 960px) and (min-width: 653px) {
+        padding: 1.5em, 0, 1.5em, 0;
+        display: inline-block;
+        width: 100%;
+      }
+
+      @media (max-width: 653px) {
+        padding-left: 30%;
+        padding-right: 30%;
+      }
+
+      @media (max-width: 450px) {
+        padding-left: 20%;
+        padding-right: 20%;
+      }
+ 
+
+        .fa {
+      
+          position: absolute;
+          margin-left: 6.25em;
+
+          @media (max-width: 960px) and (min-width: 653px) {
+            margin-left: .5em;
+            position: relative;
+          }
+      
+          @media (max-width: 653px) {
+            margin-left: 50%
+          }
+
+          @media (max-width: 450px) {
+            margin-left: 60%;
+          }
+        }
     }
   }
 }

--- a/website/src/scss/components/_dropdown.scss
+++ b/website/src/scss/components/_dropdown.scss
@@ -34,7 +34,6 @@
         padding-right: 20%;
       }
  
-
         .fa {
       
           position: absolute;
@@ -46,13 +45,37 @@
           }
       
           @media (max-width: 653px) {
-            margin-left: 50%
+            margin-left: 60%
           }
 
           @media (max-width: 450px) {
-            margin-left: 60%;
+            margin-left: 68%;
           }
         }
+        &.landing-page {
+          @media (max-width: 960px) {
+            display: flex;
+            padding-left: 28%;
+            padding-right: 28%;
+          }
+          @media (max-width: 414px) {
+            display: flex;
+            padding-left: 20%;
+            padding-right: 20%;
+          }
+
+          .fa {
+          position: absolute;
+          margin-left: 6.25em;
+
+          @media(max-width: 960px) {
+            margin-left: 60%;
+          }
+          @media(max-width: 414px) {
+            margin-left: 68%;
+          }
+        }
+      }
     }
   }
 }

--- a/website/src/scss/main.css
+++ b/website/src/scss/main.css
@@ -2381,8 +2381,42 @@ html {
   .dropdown .button__dropdown {
     text-align: center; }
   .dropdown[data-has-active-items="true"] .button__dropdown {
+    font-weight: bold;
     color: white;
-    background-color: #00BCE4; }
+    width: 100%;
+    background-color: #00BCE4;
+    white-space: initial;
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    vertical-align: middle;
+    padding: 0, 1.5em, 0, 1.5em; }
+    @media (max-width: 960px) and (min-width: 653px) {
+      .dropdown[data-has-active-items="true"] .button__dropdown {
+        padding: 1.5em, 0, 1.5em, 0;
+        display: inline-block;
+        width: 100%; } }
+    @media (max-width: 653px) {
+      .dropdown[data-has-active-items="true"] .button__dropdown {
+        padding-left: 30%;
+        padding-right: 30%; } }
+    @media (max-width: 450px) {
+      .dropdown[data-has-active-items="true"] .button__dropdown {
+        padding-left: 20%;
+        padding-right: 20%; } }
+    .dropdown[data-has-active-items="true"] .button__dropdown .fa {
+      position: absolute;
+      margin-left: 6.25em; }
+      @media (max-width: 960px) and (min-width: 653px) {
+        .dropdown[data-has-active-items="true"] .button__dropdown .fa {
+          margin-left: .5em;
+          position: relative; } }
+      @media (max-width: 653px) {
+        .dropdown[data-has-active-items="true"] .button__dropdown .fa {
+          margin-left: 50%; } }
+      @media (max-width: 450px) {
+        .dropdown[data-has-active-items="true"] .button__dropdown .fa {
+          margin-left: 60%; } }
 
 .dropdown__content {
   display: none;

--- a/website/src/scss/main.css
+++ b/website/src/scss/main.css
@@ -2413,10 +2413,29 @@ html {
           position: relative; } }
       @media (max-width: 653px) {
         .dropdown[data-has-active-items="true"] .button__dropdown .fa {
-          margin-left: 50%; } }
+          margin-left: 60%; } }
       @media (max-width: 450px) {
         .dropdown[data-has-active-items="true"] .button__dropdown .fa {
+          margin-left: 68%; } }
+    @media (max-width: 960px) {
+      .dropdown[data-has-active-items="true"] .button__dropdown.landing-page {
+        display: flex;
+        padding-left: 28%;
+        padding-right: 28%; } }
+    @media (max-width: 414px) {
+      .dropdown[data-has-active-items="true"] .button__dropdown.landing-page {
+        display: flex;
+        padding-left: 20%;
+        padding-right: 20%; } }
+    .dropdown[data-has-active-items="true"] .button__dropdown.landing-page .fa {
+      position: absolute;
+      margin-left: 6.25em; }
+      @media (max-width: 960px) {
+        .dropdown[data-has-active-items="true"] .button__dropdown.landing-page .fa {
           margin-left: 60%; } }
+      @media (max-width: 414px) {
+        .dropdown[data-has-active-items="true"] .button__dropdown.landing-page .fa {
+          margin-left: 68%; } }
 
 .dropdown__content {
   display: none;


### PR DESCRIPTION
-Filter button now displays all selected filters
-arrow replaced with filter icon when selected
-Media breakpoints implemented to keep filter button layout consistent

Let me know if any changes are wanted for font size, weight, the filter icon, or anything else

Original (for 1, 2, or 3 items selected): 

<img width="1278" alt="Screen Shot 2022-08-10 at 12 00 46 PM" src="https://user-images.githubusercontent.com/107065749/183957485-b12499bc-386a-40b7-b187-b98ca4871a4f.png">

Changes:

1 item:
<img width="1278" alt="Screen Shot 2022-08-10 at 11 58 49 AM" src="https://user-images.githubusercontent.com/107065749/183956802-6bd15fca-7f62-43a1-ad33-7fc12fe7e488.png">

2 items:
<img width="1278" alt="Screen Shot 2022-08-10 at 11 59 05 AM" src="https://user-images.githubusercontent.com/107065749/183956916-311c9e02-bdde-4e90-9ffd-3c33d50cd5f8.png">

3 items:
<img width="1278" alt="Screen Shot 2022-08-10 at 12 00 24 PM" src="https://user-images.githubusercontent.com/107065749/183957392-61dbbf07-6762-4a5e-8367-7cf6012f4b63.png">

*both still look like this when no filters are selected
<img width="1278" alt="Screen Shot 2022-08-10 at 12 02 09 PM" src="https://user-images.githubusercontent.com/107065749/183957778-de626bf5-1918-4b2b-afde-4c83ce9ece82.png">