### PR TITLE
Fields spanning multiple metadata fields are handled in backend now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Updated search bar placeholder font size and darked the text color.
 - [288](https://github.com/iodepo/OceanBestPractices/issues/288) Removed "View Tags" button and side bar from search results
+
+### Fixed
+
+- [291](https://github.com/iodepo/OceanBestPractices/issues/291) Search boolean logic now respects multi-field search fields and operators

--- a/api/README.md
+++ b/api/README.md
@@ -31,7 +31,7 @@ Search indexed documents by one or more keywords.
 | Component        | Description | Default |
 | ---------------- | ----------- | ------- |
 | LOGICAL_OPERATOR | Possible values are `+`, `-`, or blank. The operators map to `AND`, `NOT`, and `OR` respectively. | (blank) |
-| FIELD            | The index field to target with this keyword. * maps to all fields. Possible values include (but are not limited to) `title`, `primaryAuthor`, etc. | * |
+| FIELD            | The index field to target with this keyword. * maps to all fields. Possible values include (but are not limited to) `dc_title`, `dc_contributor`, etc. | * |
 | KEYWORD          | The keyword used to match documents. | * |
 
 **Optional Parameters:**

--- a/api/lambdas/search-by-keywords.test.ts
+++ b/api/lambdas/search-by-keywords.test.ts
@@ -87,8 +87,14 @@ describe('search-by-keywords.handler', () => {
 
       const doc4 = {
         uuid: uuid4,
+        dc_title: 'JERICO-S3 Deliverable 5.2. Electronic Handbook for Mature Platforms: Mooring - HF Radar - FerryBox – Glider. Version 1.1.',
         dc_identifier_doi: [
           'http://dx.doi.org/10.25607/OBP-765',
+        ],
+        dc_contributor_author: [
+          'Mantovani, Carlo',
+          'Pearlman, Jay',
+          'Simpson, Pauline',
         ],
       };
 
@@ -125,7 +131,7 @@ describe('search-by-keywords.handler', () => {
             (h) => h._source.uuid
           );
 
-          expect(uuids).toEqual([uuid1, uuid2, uuid3]);
+          expect(uuids).toEqual([uuid1, uuid3, uuid2]);
         },
         done
       );
@@ -235,7 +241,7 @@ describe('search-by-keywords.handler', () => {
             const uuids = results.hits.hits.map(
               (h) => h._source.uuid
             );
-            expect(uuids).toEqual([uuid1, uuid2, uuid3]);
+            expect(uuids).toEqual([uuid1, uuid3, uuid2]);
           },
           done
         );
@@ -260,6 +266,25 @@ describe('search-by-keywords.handler', () => {
         );
       });
 
+      test('should find matching documents using the AND boolean operator and targeted wildcard fields', (done) => {
+        const proxyEvent = {
+          queryStringParameters: {
+            keywords: ':dc_contributor\\*:pearlman,+:dc_title\\*:jerico',
+          },
+        };
+
+        searchHandler(
+          proxyEvent,
+          (results) => {
+            expect(results.hits.total.value).toEqual(1);
+
+            const [result] = results.hits.hits;
+            expect(result?._source.uuid).toEqual(uuid4);
+          },
+          done
+        );
+      });
+
       test('should find matching documents using the NOT boolean operator', (done) => {
         const proxyEvent = {
           queryStringParameters: {
@@ -275,7 +300,7 @@ describe('search-by-keywords.handler', () => {
             const uuids = results.hits.hits.map(
               (h: { _source: { uuid: string } }) => h._source.uuid
             );
-            expect(uuids).toEqual([uuid2, uuid3]);
+            expect(uuids).toEqual([uuid3, uuid2]);
           },
           done
         );

--- a/api/lib/search-query-builder.test.ts
+++ b/api/lib/search-query-builder.test.ts
@@ -124,9 +124,35 @@ describe('search-document-builder', () => {
       expect(result).toEqual('*:(or term) NOT title:(not term) AND title:(and term)');
     });
 
+    test('should build a targeted wildcard field for dc_title', () => {
+      const keywordComps = [
+        {
+          operator: '',
+          field: 'dc_title',
+          term: 'this is a title and an alternative title',
+        },
+      ];
+      const result = formatQueryString(keywordComps);
+
+      expect(result).toEqual('dc_title\\*:(this is a title and an alternative title)');
+    });
+
+    test.only('should build a targeted wildcard field for dc_contributor', () => {
+      const keywordComps = [
+        {
+          operator: '',
+          field: 'dc_contributor',
+          term: 'search all authors',
+        },
+      ];
+      const result = formatQueryString(keywordComps);
+
+      expect(result).toEqual('dc_contributor\\*:(search all authors)');
+    });
+
     test.todo('should boost the dc_title keyword field if searching all fields');
 
-    test.todo('shoudl boost the dc_description_abstract field if searching all fields');
+    test.todo('should boost the dc_description_abstract field if searching all fields');
 
     describe('when escaping query string special characters', () => {
       // + - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /

--- a/api/lib/search-query-builder.test.ts
+++ b/api/lib/search-query-builder.test.ts
@@ -137,7 +137,7 @@ describe('search-document-builder', () => {
       expect(result).toEqual('dc_title\\*:(this is a title and an alternative title)');
     });
 
-    test.only('should build a targeted wildcard field for dc_contributor', () => {
+    test('should build a targeted wildcard field for dc_contributor', () => {
       const keywordComps = [
         {
           operator: '',

--- a/api/lib/search-query-builder.ts
+++ b/api/lib/search-query-builder.ts
@@ -29,6 +29,19 @@ export const nestedQuery = (termPhrase: unknown) => ({
   },
 });
 
+// We can target wildcard fields so that search expands multiple metadata fields without
+// exposing all of our metadata to users. e.g. dc_title will also search
+// dc_title_alternative.
+const encodeQueryStringField = (field: string): string => {
+  if (field === 'dc_title') {
+    return 'dc_title\\*';
+  } if (field === 'dc_contributor') {
+    return 'dc_contributor\\*';
+  }
+
+  return field;
+};
+
 // Elasticsearch's query_string query has a list of special characters. We don't
 // want to necessarily escape them all (e.g. the user can use a wildcard if they want)
 // but there are a few obvious ones we need to escape.
@@ -57,11 +70,13 @@ const formatKeywordComp = (keywordComp: SearchKeywordComps) => {
       openSearchOperator = 'OR';
   }
 
+  const encodedKeywordCompField = encodeQueryStringField(keywordComp.field);
+
   const encodedKeywordCompTerm = encodeQueryStringTerm(
     keywordComp.term,
     keywordComp.field
   );
-  return `${openSearchOperator} ${keywordComp.field}:(${encodedKeywordCompTerm})`;
+  return `${openSearchOperator} ${encodedKeywordCompField}:(${encodedKeywordCompTerm})`;
 };
 
 /**

--- a/website/src/js/reducers/fields.js
+++ b/website/src/js/reducers/fields.js
@@ -19,9 +19,7 @@ const initialState = [
     title: 'Author',
     id: 'author',
     value: [
-      'dc_contributor_author',
-      'dc_contributor_corpauthor',
-      'dc_contributor_editor',
+      'dc_contributor',
     ],
     active_search: false,
     help_text: 'Enter the <b>author name</b>. You can enter just the surname if it is not a common name otherwise eg.  Johannes Karstensen or if you know more than one author  Karstensen Pearlman',
@@ -32,7 +30,6 @@ const initialState = [
     id: 'title',
     value: [
       'dc_title',
-      'dc_title_alternative',
     ],
     active_search: false,
     autocomplete: true,


### PR DESCRIPTION
Closes #291

This PR addresses an issue where searching from the UI for `dc_title` would search both `dc_title` and `dc_title_alternative`. Normally that's what we want; however, when using the boolean operator AND this resulted in searches for `dc_title` AND `dc_title_alternative`. Some documents don't have an alternative title and the search would fail.

Instead, now, the UI just passes `dc_title` and the backend determines which fields to use in a way that produces the results we want.

Also updated for `dc_contributor*` (author, editor, etc).